### PR TITLE
Remove hover from mobile menu

### DIFF
--- a/src/components/Navbar/Navbar.astro
+++ b/src/components/Navbar/Navbar.astro
@@ -141,7 +141,7 @@ const url = Astro.url.pathname
                       viewBox="0 0 24 24"
                       stroke-width="1.5"
                       stroke="currentColor"
-                      class="ml-1 w-4 h-4 inline-block pointer-events-none"
+                      class="ml-1 w-4 h-4 hidden lg:inline-block pointer-events-none"
                     >
                       <path
                         stroke-linecap="round"
@@ -154,7 +154,8 @@ const url = Astro.url.pathname
                 {item.children && (
                   <ul
                     class={`
-                    hidden
+                    block
+                    lg:hidden
                     group-hover:block
                     group-focus-within:block
                     lg:absolute


### PR DESCRIPTION
The dropdowns in the mobile menu felt off, so this PR disables them. Let me know if you like it.